### PR TITLE
Fix content failing to load when served from HTTPS due to insecure content.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:300,600);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:300,600);
 
 body {
     font-family: 'Open Sans', sans-serif;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 	<link type="text/css" href="css/main.css" media="all" rel="stylesheet">
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
 	<script src="js/timezone_detect.js"></script>
 	<script>
 		$(function() {


### PR DESCRIPTION
In his 2014 update to [this article](http://www.paulirish.com/2010/the-protocol-relative-url/), @paulirish says:

> If the asset you need is available on SSL, then always use the https:// asset.
> 
> Allowing the snippet to request over HTTP opens the door for attacks like the recent Github Man-on-the-side attack. It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is not true.
